### PR TITLE
Update for latest version of Swift

### DIFF
--- a/Sources/SwiftLeftpad.swift
+++ b/Sources/SwiftLeftpad.swift
@@ -8,7 +8,7 @@ extension String {
         
         var i = 0
         while (i < extraLength) {
-            outString.insert(character, at: outString.startIndex)
+            outString.insert(character, atIndex: outString.startIndex)
             i += 1
         }
         


### PR DESCRIPTION
Uses atIndex rather than at in Swift v2.2 and later
